### PR TITLE
Addition of version build-arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
 FROM openjdk
 MAINTAINER Joel Courtney <joel@enosi.io>
 
-RUN curl https://oss.sonatype.org/content/repositories/public/io/hawt/hawtio-app/2.7.0/hawtio-app-2.7.0.jar \
-  --output hawtio-app-2.7.0.jar && \
-  chmod 755 hawtio-app-2.7.0.jar
+ARG version=2.7.0
+ENV hawtio_version=${version}
+
+RUN curl https://oss.sonatype.org/content/repositories/public/io/hawt/hawtio-app/${hawtio_version}/hawtio-app-${hawtio_version}.jar \
+  --output hawtio-app.jar && \
+  chmod 755 hawtio-app.jar
 
 EXPOSE 8080
 
 ENTRYPOINT ["/bin/bash", "-c"]
-CMD ["java -Dhawtio.proxyWhitelist=* -jar hawtio-app-2.7.0.jar"]
+CMD ["java -Dhawtio.proxyWhitelist=* -jar hawtio-app.jar"]

--- a/README.md
+++ b/README.md
@@ -9,9 +9,23 @@ Hosted on [dockerhub](https://hub.docker.com/) at:
 
 > [cloud.docker.com/u/enosi/repository/docker/enosi/hawtio-docker/general](https://cloud.docker.com/u/enosi/repository/docker/enosi/hawtio-docker/general)
 
+## Want another version?
+
+By default, `hawtio-docker` currently builds with a default release version of
+v[2.7.0](https://github.com/hawtio/hawtio/tree/hawtio-2.7.0).
+
+Want a different version of [hawtio](https://github.com/hawtio/hawtio/releases)?
+Then you're in luck thanks to the use of a docker `build-arg`.
+
+```sh
+docker build --build-arg version=2.6.0 -t hawtio-2.6.0 .
+```
+
+This will give you a container running v[2.6.0](https://github.com/hawtio/hawtio/tree/hawtio-2.6.0).
+
 ## To use hawtio docker
 
-```
+```sh
 docker run --rm -p 8081:8080 enosi/hawtio-docker:latest
 ```
 


### PR DESCRIPTION
Addition of version build-arg to allow for the selection of the desired version of https://hawt.io/ rather than specifying one.